### PR TITLE
upgrade `ip-address` to 5.8

### DIFF
--- a/lib/IPAddress.js
+++ b/lib/IPAddress.js
@@ -1,20 +1,25 @@
 'use strict';
 
-var IPv6 = require('ip-address').v6;
-var IPv4 = require('ip-address').v4;
+var IPv6 = require('ip-address').Address6;
+var IPv4 = require('ip-address').Address4;
+
+exports.parseIPv6 = function parseIPv6(ip) {
+    var address = new IPv6(ip);
+    // we got an hybrid IP format. convert the IP into v4
+    if (address.v4) {
+      address = address.to4();
+    }
+    if (!address.isValid()) {
+        throw new Error("Invalid IPv6 address");
+    }
+    return address.parsedAddress;
+};
+
 
 exports.parseIPv4 = function parseIPv4(ip) {
-    var v4Address = new IPv4.Address(ip);
+    var v4Address = new IPv4(ip);
     if (!v4Address.isValid()) {
         throw new Error("Invalid IPv4 address");
     }
     return v4Address.parsedAddress;
-};
-
-exports.parseIPv6 = function parseIPv6(ip) {
-    var v6Address = new IPv6.Address(ip);
-    if (!v6Address.isValid()) {
-        throw new Error("Invalid IPv6 address");
-    }
-    return v6Address.parsedAddress;
 };

--- a/lib/IPParser.js
+++ b/lib/IPParser.js
@@ -5,10 +5,10 @@ var IPAddress = require('./IPAddress');
 module.exports = IPParser;
 
 function IPParser(ip) {
-    if (ip.indexOf('.') !== -1) {
-        return IPParser.parseIPv4(ip);
+    if (ip.indexOf(':') !== -1) {
+      return IPParser.parseIPv6(ip);
     } else {
-        return IPParser.parseIPv6(ip);
+      return IPParser.parseIPv4(ip);
     }
 }
 
@@ -17,7 +17,11 @@ IPParser.parseIPv4 = function parseIPv4(ip) {
 };
 
 IPParser.parseIPv6 = function parseIPv6(ip) {
-    return ipv6Buffer(IPAddress.parseIPv6(ip));
+    const parserBuffer = IPAddress.parseIPv6(ip);
+    if (Array.isArray(parserBuffer) && parserBuffer.length == 4){
+      return ipv4Buffer(parserBuffer);
+    }
+    return ipv6Buffer(parserBuffer);
 };
 
 function ipv4Buffer(groups) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "big-integer": ">=1.1.5",
-        "ip-address": "4.0.0"
+        "ip-address": "5.8.0"
     },
     "devDependencies": {
         "istanbul": "^0.3.13",


### PR DESCRIPTION
this version support conversion of hybrid address (e.g "::ffff:98.195.255.254")
in to v4 format
